### PR TITLE
fix: support unlimited include: nesting depth in resource set collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog
+
+## v1.11.1 (2026-06-12)
+
+### Bug Fixes
+
+- **Unlimited `include:` nesting depth** — resource set collections previously silently ignored
+  any `include:` entries beyond a single level of nesting. The path flattening logic is now
+  recursive, so deeply nested collections (3+ levels) resolve correctly with proper name
+  hierarchy, absolute paths, and inherited variable merging at each level.
+
+### Build
+
+- `build-release.sh init` now pins `github.com/imdario/mergo` to `v0.3.16` and adds a `replace`
+  directive for the `gopkg.in/alecthomas/kingpin.v2` → `github.com/alecthomas/kingpin/v2` module
+  rename, so `init` produces a working `go.mod` without manual intervention.
+
+---
+
+## v1.10.1 (2022-03-01)
+
+### New Features
+
+- **Server-Side Apply (`--ssa`)** — `kontemplate apply` now accepts an `--ssa` flag that passes
+  `--server-side` to `kubectl apply`. Useful for resources whose manifests exceed the
+  `kubectl.kubernetes.io/last-applied-configuration` annotation size limit.
+
+### Bug Fixes
+
+- Deduplicated the `--dry-run` argument-building logic in `applyCommand` (previously the
+  `kubectlArgs` slice was being assembled twice, with the second assignment silently discarding
+  the first).
+- Fixed inconsistent indentation in `deleteCommand`.
+
+---
+
+## v1.10.0 / v1.9.0
+
+- Added `--server` flag to `apply` for server-side dry-runs (`--dry-run=server`).
+- Added `--ignore` flag to `delete` to pass `--ignore-not-found=true` to kubectl.
+- Added macOS Fat Binary (universal arm64+amd64), Linux ARM64, and Linux ARM builds to the
+  release matrix.

--- a/build-release.sh
+++ b/build-release.sh
@@ -12,7 +12,7 @@ set -eo pipefail
 
 readonly GIT_HASH="$(git rev-parse --short HEAD)"
 readonly LDFLAGS="-X main.gitHash=${GIT_HASH} -w -s"
-readonly VERSION="1.10.1-${GIT_HASH}"
+readonly VERSION="1.11.1-${GIT_HASH}"
 
 function binary-name() {
     local os="${1}"
@@ -83,6 +83,10 @@ case "${1}" in
         rm -rf release
         rm -rf go.mod go.sum
         go mod init github.com/ksquaredkey/kontemplate
+        # kingpin moved from gopkg.in/alecthomas/kingpin.v2 to github.com/alecthomas/kingpin/v2
+        echo 'replace gopkg.in/alecthomas/kingpin.v2 => github.com/alecthomas/kingpin/v2 v2.4.0' >> go.mod
+        # mergo moved from github.com/imdario/mergo to dario.cat/mergo at v1.0.0; pin to pre-rename
+        go get github.com/imdario/mergo@v0.3.16
         go mod tidy
         exit 0
         ;;

--- a/context/context.go
+++ b/context/context.go
@@ -152,23 +152,31 @@ func flattenPrepareResourceSetPaths(baseDir *string, rs *[]ResourceSet) []Resour
 			r.Path = path.Join(*baseDir, r.Path)
 		}
 
-		if len(r.Include) == 0 {
-			flattened = append(flattened, r)
-		} else {
-			for _, subResourceSet := range r.Include {
-				if subResourceSet.Path == "" {
-					subResourceSet.Path = subResourceSet.Name
-				}
-
-				subResourceSet.Parent = r.Name
-				subResourceSet.Name = path.Join(r.Name, subResourceSet.Name)
-				subResourceSet.Path = path.Join(r.Path, subResourceSet.Path)
-				subResourceSet.Values = *util.Merge(&r.Values, &subResourceSet.Values)
-				flattened = append(flattened, subResourceSet)
-			}
-		}
+		flattened = append(flattened, flattenResourceSet(r)...)
 	}
 
+	return flattened
+}
+
+// Recursively flattens a resource set and all of its nested includes into a flat list.
+// The resource set's Path must already be absolute before calling this function.
+func flattenResourceSet(rs ResourceSet) []ResourceSet {
+	if len(rs.Include) == 0 {
+		return []ResourceSet{rs}
+	}
+
+	flattened := make([]ResourceSet, 0)
+	for _, sub := range rs.Include {
+		if sub.Path == "" {
+			sub.Path = sub.Name
+		}
+
+		sub.Parent = rs.Name
+		sub.Name = path.Join(rs.Name, sub.Name)
+		sub.Path = path.Join(rs.Path, sub.Path)
+		sub.Values = *util.Merge(&rs.Values, &sub.Values)
+		flattened = append(flattened, flattenResourceSet(sub)...)
+	}
 	return flattened
 }
 

--- a/context/context_test.go
+++ b/context/context_test.go
@@ -312,6 +312,34 @@ func TestExplicitSubresourcePathLoading(t *testing.T) {
 	}
 }
 
+func TestDeepNestedResourceSets(t *testing.T) {
+	ctx, err := LoadContext("testdata/deep-collections-test.yaml", &noExplicitVars)
+
+	if err != nil {
+		t.Error(err)
+		t.Fail()
+	}
+
+	if len(ctx.ResourceSets) != 1 {
+		t.Errorf("Expected 1 resource set, got %d", len(ctx.ResourceSets))
+		t.Fail()
+	}
+
+	rs := ctx.ResourceSets[0]
+	if rs.Name != "level1/level2/level3" {
+		t.Errorf("Expected name 'level1/level2/level3', got '%s'", rs.Name)
+		t.Fail()
+	}
+	if rs.Parent != "level1/level2" {
+		t.Errorf("Expected parent 'level1/level2', got '%s'", rs.Parent)
+		t.Fail()
+	}
+	if rs.Values["inherited"] != true {
+		t.Errorf("Expected inherited variable to be true, got %v", rs.Values["inherited"])
+		t.Fail()
+	}
+}
+
 func TestSetVariablesFromArguments(t *testing.T) {
 	vars := []string{"version=some-service-version"}
 	ctx, _ := LoadContext("testdata/default-loading.yaml", &vars)

--- a/context/testdata/deep-collections-test.yaml
+++ b/context/testdata/deep-collections-test.yaml
@@ -1,0 +1,12 @@
+---
+context: k8s.prod.mydomain.com
+include:
+  - name: level1
+    values:
+      inherited: true
+    include:
+      - name: level2
+        include:
+          - name: level3
+            values:
+              own: value

--- a/docs/resource-sets.md
+++ b/docs/resource-sets.md
@@ -160,11 +160,9 @@ Variables specified in the parent resource set are inherited by the children.
 
 ### Caveats
 
-Two caveats apply that users should be aware of:
+One caveat applies that users should be aware of:
 
 1. The parent resource set can not contain any resource templates itself.
-
-2. Only one level of nesting is supported. Specifying `include` again on a nested resource set will be ignored.
 
 [templates]: templates.md
 [cluster configuration]: cluster-config.md

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
-const version string = "1.10.1"
+const version string = "1.11.1"
 
 // This variable will be initialised by the Go linker during the builder
 var gitHash string


### PR DESCRIPTION
## Summary

- Fixes a bug where `include:` directives beyond one level of nesting were silently ignored, causing resources at depth 3+ to never be resolved
- Replaces the single-pass `flattenPrepareResourceSetPaths` loop with a recursive `flattenResourceSet` helper — name hierarchy, absolute paths, and inherited variable merging now work correctly at any depth
- Bumps release to v1.11.1

## Changes

- `context/context.go` — new recursive `flattenResourceSet` function; `flattenPrepareResourceSetPaths` simplified to delegate to it
- `context/context_test.go` — adds `TestDeepNestedResourceSets` covering a 3-level include
- `docs/resource-sets.md` — removes the stale caveat that said only one level of nesting was supported
- `build-release.sh` — version bumped to 1.11.1; `init` case now pins `github.com/imdario/mergo@v0.3.16` and adds a `replace` directive for the `gopkg.in/alecthomas/kingpin.v2` → `github.com/alecthomas/kingpin/v2` module rename so `init` produces a working `go.mod` without manual intervention
- `CHANGELOG.md` — added

## Test plan

- [ ] `go test ./context/...` passes (all existing tests + new `TestDeepNestedResourceSets`)
- [ ] `bash build-release.sh init && bash build-release.sh build` produces binaries for all 7 targets cleanly
- [ ] Verify a context YAML with 3-level `include:` nesting resolves resources correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)