### PR TITLE
feat: update Homebrew formula to v1.11.1 with multi-arch support

### DIFF
--- a/kontemplate.rb
+++ b/kontemplate.rb
@@ -3,9 +3,17 @@
 class Kontemplate < Formula
   desc "Kontemplate - Extremely simple Kubernetes resource templates"
   homepage "https://github.com/ksquaredkey/kontemplate"
-  url "https://github.com/ksquaredkey/kontemplate/releases/download/v1.10.1/kontemplate-1.10.1-f8d086a-darwin-amd64.tar.gz"
-  sha256 "4a52d37745355091cebea63e9b02d2242112c62b148087f4c646f52ad1921e6d"
-  version "kontemplate-1.10.1-f8d086a"
+  version "kontemplate-1.11.1-bd60ad8"
+
+  on_intel do
+    url "https://github.com/ksquaredkey/kontemplate/releases/download/v1.11.1/kontemplate-1.11.1-bd60ad8-darwin-amd64.tar.gz"
+    sha256 "a9a1d54abdff209e1ece58caac552348b474979b8cd192a3fd3bdbe14457bba8"
+  end
+
+  on_arm do
+    url "https://github.com/ksquaredkey/kontemplate/releases/download/v1.11.1/kontemplate-1.11.1-bd60ad8-darwin-arm64.tar.gz"
+    sha256 "3c05264c7166528fb33d07e1ecea9f378604bfc1e75dee7a3327513995c8b4b2"
+  end
 
   def install
     bin.install "kontemplate"


### PR DESCRIPTION
## Summary

- Updates `kontemplate.rb` from v1.10.1 (amd64-only) to v1.11.1
- Adds `on_intel`/`on_arm` blocks to support both `darwin-amd64` and `darwin-arm64`
- SHA256 checksums pulled directly from the v1.11.1 GitHub release assets

## Test plan

- [ ] `brew install --formula kontemplate.rb` on an Intel Mac installs the amd64 binary
- [ ] `brew install --formula kontemplate.rb` on an Apple Silicon Mac installs the arm64 binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)